### PR TITLE
Improving performance of event hook registry.

### DIFF
--- a/src/de.systemticks.ebrace.core.eventhook/OSGI-INF/de.systemticks.ebrace.core.eventhook.impl.EventHookRegistryServiceImpl.xml
+++ b/src/de.systemticks.ebrace.core.eventhook/OSGI-INF/de.systemticks.ebrace.core.eventhook.impl.EventHookRegistryServiceImpl.xml
@@ -3,5 +3,6 @@
    <service>
       <provide interface="de.systemticks.ebrace.core.eventhook.registry.api.EventHookRegistry"/>
    </service>
+   <reference bind="bindEventHook" cardinality="0..n" interface="de.systemticks.ebrace.core.eventhook.registry.api.EventHook" name="EventHook" policy="dynamic" unbind="unbindEventHook"/>
    <implementation class="de.systemticks.ebrace.core.eventhook.impl.EventHookRegistryServiceImpl"/>
 </scr:component>

--- a/src/de.systemticks.ebrace.core.eventhook/src/de/systemticks/ebrace/core/eventhook/impl/EventHookRegistryServiceImpl.java
+++ b/src/de.systemticks.ebrace.core.eventhook/src/de/systemticks/ebrace/core/eventhook/impl/EventHookRegistryServiceImpl.java
@@ -9,49 +9,59 @@
  ******************************************************************************/
 package de.systemticks.ebrace.core.eventhook.impl;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
-import com.elektrobit.ebrace.common.utils.GenericOSGIServiceTracker;
 import com.elektrobit.ebsolys.core.targetdata.api.runtime.eventhandling.RuntimeEvent;
 
 import de.systemticks.ebrace.core.eventhook.registry.api.EventHook;
-import de.systemticks.ebrace.core.eventhook.registry.api.EventHookCollector;
 import de.systemticks.ebrace.core.eventhook.registry.api.EventHookRegistry;
 
 @Component(immediate = true, enabled = true)
 public class EventHookRegistryServiceImpl implements EventHookRegistry
 {
-    private final EventHookCollector collector;
+    private final Set<EventHook> hooks = new CopyOnWriteArraySet<>();
 
     public EventHookRegistryServiceImpl()
     {
-        collector = new EventHookCollector()
-        {
-            @Override
-            public List<EventHook> getEventHooks()
-            {
-                GenericOSGIServiceTracker<EventHook> serviceTracker = new GenericOSGIServiceTracker<EventHook>( EventHook.class );
-                Map<Object, Properties> servicesMap = serviceTracker.getServices( EventHook.class.getName() );
-                Set<Object> eventHookObjects = servicesMap.keySet();
-                List<EventHook> eventHooks = new ArrayList<EventHook>();
-                for (Object eventHookObject : eventHookObjects)
-                {
-                    eventHooks.add( (EventHook)eventHookObject );
-                }
-                return eventHooks;
-            }
-        };
+        // hooks = new EventHookCollector()
+        // {
+        // @Override
+        // public List<EventHook> getEventHooks()
+        // {
+        // GenericOSGIServiceTracker<EventHook> serviceTracker = new GenericOSGIServiceTracker<EventHook>(
+        // EventHook.class );
+        // Map<Object, Properties> servicesMap = serviceTracker.getServices( EventHook.class.getName() );
+        // Set<Object> eventHookObjects = servicesMap.keySet();
+        // List<EventHook> eventHooks = new ArrayList<EventHook>();
+        // for (Object eventHookObject : eventHookObjects)
+        // {
+        // eventHooks.add( (EventHook)eventHookObject );
+        // }
+        // return eventHooks;
+        // }
+        // }.getEventHooks();
+    }
+
+    @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)
+    public void bindEventHook(EventHook hook)
+    {
+        hooks.add( hook );
+    }
+
+    public void unbindEventHook(EventHook hook)
+    {
+        hooks.remove( hook );
     }
 
     @Override
     public void callFor(RuntimeEvent<?> event)
     {
-        collector.getEventHooks().forEach( hook -> hook.onEvent( event ) );
+        hooks.forEach( hook -> hook.onEvent( event ) );
     }
 }

--- a/src/de.systemticks.ebrace.core.eventhook/src/de/systemticks/ebrace/core/eventhook/impl/EventHookRegistryServiceImpl.java
+++ b/src/de.systemticks.ebrace.core.eventhook/src/de/systemticks/ebrace/core/eventhook/impl/EventHookRegistryServiceImpl.java
@@ -29,23 +29,6 @@ public class EventHookRegistryServiceImpl implements EventHookRegistry
 
     public EventHookRegistryServiceImpl()
     {
-        // hooks = new EventHookCollector()
-        // {
-        // @Override
-        // public List<EventHook> getEventHooks()
-        // {
-        // GenericOSGIServiceTracker<EventHook> serviceTracker = new GenericOSGIServiceTracker<EventHook>(
-        // EventHook.class );
-        // Map<Object, Properties> servicesMap = serviceTracker.getServices( EventHook.class.getName() );
-        // Set<Object> eventHookObjects = servicesMap.keySet();
-        // List<EventHook> eventHooks = new ArrayList<EventHook>();
-        // for (Object eventHookObject : eventHookObjects)
-        // {
-        // eventHooks.add( (EventHook)eventHookObject );
-        // }
-        // return eventHooks;
-        // }
-        // }.getEventHooks();
     }
 
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)


### PR DESCRIPTION
Storing reference to event hook, when it get registered. Do not fetching all event hooks, when hooks get called. 