### PR TITLE
Fixing is not json exception.

### DIFF
--- a/src/com.elektrobit.ebrace.viewer.runtimeeventloggertable/src/com/elektrobit/ebrace/viewer/runtimeeventloggertable/labelprovider/ValueColumnLabelProvider.java
+++ b/src/com.elektrobit.ebrace.viewer.runtimeeventloggertable/src/com/elektrobit/ebrace/viewer/runtimeeventloggertable/labelprovider/ValueColumnLabelProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 
+import com.elektrobit.ebrace.common.utils.JsonHelper;
 import com.elektrobit.ebrace.common.utils.SimpleJsonPath;
 import com.elektrobit.ebrace.core.interactor.api.resources.model.table.TableModel;
 import com.elektrobit.ebrace.core.interactor.api.table.Position;
@@ -135,8 +136,11 @@ public class ValueColumnLabelProvider extends StyledCellLabelProvider implements
             {
                 if (event.getValue() instanceof String)
                 {
-                    result = new SimpleJsonPath( (String)event.getValue() )
-                            .stringValueOf( "value.details." + columnName );
+                    String valueAsString = (String)event.getValue();
+                    if (JsonHelper.isJson( valueAsString ))
+                    {
+                        result = new SimpleJsonPath( valueAsString ).stringValueOf( "value.details." + columnName );
+                    }
                 }
             }
         }


### PR DESCRIPTION
If someone mixes a plain string channel and a json channel,
then an exception was thrown, because it tries to parse the
string as json. Now we check if it is a valid json string.