### PR TITLE
Changes for Log4j trace handling:

### DIFF
--- a/src/com.elektrobit.ebrace.targetdata.adapter.log4jtargetadapter/META-INF/MANIFEST.MF
+++ b/src/com.elektrobit.ebrace.targetdata.adapter.log4jtargetadapter/META-INF/MANIFEST.MF
@@ -9,7 +9,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.log4j;bundle-version="1.2.15",
  com.elektrobit.ebrace.core.targetdata.api;bundle-version="1.0.0",
  com.elektrobit.ebrace.protobuf.messagedefinitions;bundle-version="1.0.0",
- org.eclipse.osgi.services
+ org.eclipse.osgi.services,
+ com.google.gson;bundle-version="2.1.0",
+ com.elektrobit.ebrace.common;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Import-Package: com.elektrobit.ebrace.chronograph.api,

--- a/src/com.elektrobit.ebrace.targetdata.adapter.log4jtargetadapter/src/com/elektrobit/ebrace/targetdata/adapter/log4jtargetadapter/internal/Log4jRuntimeEventCreator.java
+++ b/src/com.elektrobit.ebrace.targetdata.adapter.log4jtargetadapter/src/com/elektrobit/ebrace/targetdata/adapter/log4jtargetadapter/internal/Log4jRuntimeEventCreator.java
@@ -8,25 +8,86 @@
  * SPDX-License-Identifier: EPL-2.0
  ******************************************************************************/
 package com.elektrobit.ebrace.targetdata.adapter.log4jtargetadapter.internal;
+
+import com.elektrobit.ebrace.common.utils.JsonHelper;
+import com.elektrobit.ebrace.core.targetdata.api.json.JsonEvent;
+import com.elektrobit.ebrace.core.targetdata.api.json.JsonEventEdge;
+import com.elektrobit.ebrace.core.targetdata.api.json.JsonEventHandler;
+import com.elektrobit.ebrace.core.targetdata.api.json.JsonEventValue;
 import com.elektrobit.ebrace.targetdata.adapter.log4j.Log4jTAProto.LogData;
 import com.elektrobit.ebsolys.core.targetdata.api.adapter.Timestamp;
 import com.elektrobit.ebsolys.core.targetdata.api.runtime.eventhandling.RuntimeEventAcceptor;
 import com.elektrobit.ebsolys.core.targetdata.api.runtime.eventhandling.RuntimeEventChannel;
 import com.elektrobit.ebsolys.core.targetdata.api.runtime.eventhandling.Unit;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 public class Log4jRuntimeEventCreator
 {
-    public RuntimeEventAcceptor runtimeEventAcceptor;
+    private final static String IPC_IDENTIFIER = "ipc";
+    private final static String EDGE_IDENTIFIER = "edge";
 
     public static void createRuntimeEvent(LogData parsedMessage, Timestamp timestamp,
+            RuntimeEventAcceptor runtimeEventAcceptor, JsonEventHandler jsonEventHandler)
+    {
+        // handle message as IPC call, if logger starts with 'ipc' and payload is valid json
+        if (parsedMessage.getLogLevel().startsWith( IPC_IDENTIFIER ) && JsonHelper.isJson( parsedMessage.getTrace() ))
+        {
+            Gson gson = new Gson();
+            JsonParser parser = new JsonParser();
+            JsonObject orig = parser.parse( parsedMessage.getTrace() ).getAsJsonObject();
+
+            if (orig.get( EDGE_IDENTIFIER ) != null)
+            {
+                JsonEventEdge eventEdge = gson.fromJson( orig.get( EDGE_IDENTIFIER ), JsonEventEdge.class );
+
+                JsonObject details = new JsonObject();
+                orig.entrySet().stream().filter( e -> !e.getKey().equals( EDGE_IDENTIFIER ) )
+                        .forEach( e -> details.add( e.getKey(), e.getValue() ) );
+
+                JsonEventValue value = new JsonEventValue( makeSummaryHeader( eventEdge ) + details.toString(),
+                                                           details );
+                JsonEvent evt = new JsonEvent( timestamp.getTimeInMillis()
+                        * 1000, parsedMessage.getLogLevel(), value, null, eventEdge );
+
+                jsonEventHandler.handle( evt );
+            }
+            else
+            {
+                handleAsPlainText( parsedMessage, timestamp, runtimeEventAcceptor );
+            }
+
+        }
+        else
+        {
+            handleAsPlainText( parsedMessage, timestamp, runtimeEventAcceptor );
+        }
+    }
+
+    private static String makeSummaryHeader(JsonEventEdge edge)
+    {
+        switch (edge.getType())
+        {
+            case "request" :
+                return "-> ";
+            case "response" :
+                return "<- ";
+            case "broadcast" :
+                return "<-- ";
+            default :
+                return "? ";
+        }
+    }
+
+    private static void handleAsPlainText(LogData parsedMessage, Timestamp timestamp,
             RuntimeEventAcceptor runtimeEventAcceptor)
     {
-        RuntimeEventChannel<String> channel = runtimeEventAcceptor
-                .createOrGetRuntimeEventChannel( "trace.log4j." + parsedMessage.getLogLevel(), Unit.TEXT, "log4j data" );
+        RuntimeEventChannel<String> channel = runtimeEventAcceptor.createOrGetRuntimeEventChannel( "trace.log4j."
+                + parsedMessage.getLogLevel(), Unit.TEXT, "log4j data" );
 
-        runtimeEventAcceptor.acceptEventMicros( timestamp.getTimeInMillis() * 1000,
-                                                channel,
-                                                null,
-                                                parsedMessage.getTrace() );
+        runtimeEventAcceptor
+                .acceptEventMicros( timestamp.getTimeInMillis() * 1000, channel, null, parsedMessage.getTrace() );
     }
+
 }

--- a/src/com.elektrobit.ebrace.targetdata.adapter.log4jtargetadapter/src/com/elektrobit/ebrace/targetdata/adapter/log4jtargetadapter/internal/Log4jTargetAdapter.java
+++ b/src/com.elektrobit.ebrace.targetdata.adapter.log4jtargetadapter/src/com/elektrobit/ebrace/targetdata/adapter/log4jtargetadapter/internal/Log4jTargetAdapter.java
@@ -10,6 +10,7 @@
 package com.elektrobit.ebrace.targetdata.adapter.log4jtargetadapter.internal;
 
 import com.elektrobit.ebrace.chronograph.api.TimestampProvider;
+import com.elektrobit.ebrace.core.targetdata.api.json.JsonEventHandler;
 import com.elektrobit.ebrace.targetagent.protocol.commondefinitions.TargetAgentProtocolCommonDefinitions;
 import com.elektrobit.ebrace.targetagent.protocol.commondefinitions.TargetAgentProtocolCommonDefinitions.MessageType;
 import com.elektrobit.ebrace.targetdata.adapter.log4j.Log4jTAProto;
@@ -29,11 +30,14 @@ public class Log4jTargetAdapter implements TargetAdapter
 {
 
     private final RuntimeEventAcceptor runtimeEventAcceptor;
+    private final JsonEventHandler jsonEventHandler;
 
     public Log4jTargetAdapter(RuntimeEventAcceptor runtimeEventAcceptor, TimestampProvider tsProvider,
-            ComRelationAcceptor comRelationAcceptor, DataSourceContext dataSourceContext)
+            ComRelationAcceptor comRelationAcceptor, JsonEventHandler jsonEventHandler,
+            DataSourceContext dataSourceContext)
     {
         this.runtimeEventAcceptor = runtimeEventAcceptor;
+        this.jsonEventHandler = jsonEventHandler;
     }
 
     @Override
@@ -49,7 +53,8 @@ public class Log4jTargetAdapter implements TargetAdapter
             try
             {
                 message = Log4jTAProto.LogData.parseFrom( payload );
-                Log4jRuntimeEventCreator.createRuntimeEvent( message, timestamp, runtimeEventAcceptor );
+                Log4jRuntimeEventCreator
+                        .createRuntimeEvent( message, timestamp, runtimeEventAcceptor, jsonEventHandler );
 
             }
             catch (InvalidProtocolBufferException e)

--- a/src/com.elektrobit.ebrace.targetdata.adapter.log4jtargetadapter/src/com/elektrobit/ebrace/targetdata/adapter/log4jtargetadapter/internal/Log4jTargetAdapterFactory.java
+++ b/src/com.elektrobit.ebrace.targetdata.adapter.log4jtargetadapter/src/com/elektrobit/ebrace/targetdata/adapter/log4jtargetadapter/internal/Log4jTargetAdapterFactory.java
@@ -16,6 +16,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import com.elektrobit.ebrace.chronograph.api.TimestampProvider;
+import com.elektrobit.ebrace.core.targetdata.api.json.JsonEventHandler;
 import com.elektrobit.ebsolys.core.targetdata.api.adapter.BaseTargetAdapterFactory;
 import com.elektrobit.ebsolys.core.targetdata.api.adapter.DataSourceContext;
 import com.elektrobit.ebsolys.core.targetdata.api.adapter.TargetAdaptorFactory;
@@ -29,14 +30,16 @@ public class Log4jTargetAdapterFactory extends BaseTargetAdapterFactory<Log4jTar
     private RuntimeEventAcceptor runtimeEventAcceptor;
     private ComRelationAcceptor comRelationAcceptor;
     private TimestampProvider tsProvider;
+    private JsonEventHandler jsonEventHandler = null;
 
     @Override
     protected Log4jTargetAdapter createNewAdapterInstance(DataSourceContext dataSourceContext)
     {
         return new Log4jTargetAdapter( runtimeEventAcceptor,
-                                              tsProvider,
-                                              comRelationAcceptor,
-                                              dataSourceContext );
+                                       tsProvider,
+                                       comRelationAcceptor,
+                                       jsonEventHandler,
+                                       dataSourceContext );
     }
 
     @Override
@@ -78,4 +81,14 @@ public class Log4jTargetAdapterFactory extends BaseTargetAdapterFactory<Log4jTar
         this.comRelationAcceptor = null;
     }
 
+    @Reference
+    public void bindJsonService(JsonEventHandler jsonEventHandler)
+    {
+        this.jsonEventHandler = jsonEventHandler;
+    }
+
+    public void unbindJsonService(JsonEventHandler jsonEventHandler)
+    {
+        this.jsonEventHandler = null;
+    }
 }

--- a/src/com.elektrobit.ebrace.viewer.runtimeeventloggertable/src/com/elektrobit/ebrace/viewer/runtimeeventloggertable/editor/RuntimeEventLoggerTableEditor.java
+++ b/src/com.elektrobit.ebrace.viewer.runtimeeventloggertable/src/com/elektrobit/ebrace/viewer/runtimeeventloggertable/editor/RuntimeEventLoggerTableEditor.java
@@ -409,12 +409,11 @@ public class RuntimeEventLoggerTableEditor extends EditorPart
 
         List<String> channelsWithoutDuplicates = allColumnNames.stream().distinct().collect( Collectors.toList() );
 
-        // "Value" column should be rightmost before the channel column
-        addAdditionalValueColumn( "Value" );
-
         channelsWithoutDuplicates.stream().filter( columnName -> !columnName.equals( "Value" ) )
                 .forEach( columnName -> addAdditionalValueColumn( columnName ) );
 
+        // "Value" column should be rightmost before the channel column
+        addAdditionalValueColumn( "Value" );
     }
 
     private void addAdditionalValueColumn(String columnName)

--- a/src/com.elektrobit.ebrace.viewer.runtimeeventloggertable/src/com/elektrobit/ebrace/viewer/runtimeeventloggertable/editor/RuntimeEventLoggerTableEditor.java
+++ b/src/com.elektrobit.ebrace.viewer.runtimeeventloggertable/src/com/elektrobit/ebrace/viewer/runtimeeventloggertable/editor/RuntimeEventLoggerTableEditor.java
@@ -173,6 +173,12 @@ public class RuntimeEventLoggerTableEditor extends EditorPart
     private final Set<RuntimeEventChannel<?>> currentChannels = new HashSet<>();
     private AllChannelsNotifyUseCase allChannelsNotifyUseCase;
 
+    private TableViewerColumn analysisColumn;
+
+    private TableViewerColumn tagColumn;
+
+    private TableViewerColumn colorColumn;
+
     @Override
     public void init(IEditorSite site, IEditorInput input) throws PartInitException
     {
@@ -307,7 +313,11 @@ public class RuntimeEventLoggerTableEditor extends EditorPart
         filteredTable.getViewer().getTable().setRedraw( false );
         TableColumnWidthProvider widthProvider = new TableColumnWidthProvider( tableContainer.getClientArea().width,
                                                                                valueColumns.size() - 1 );
+        analysisColumn.getColumn()
+                .setWidth( TableColumnWidthProvider.FixedColumnWidths.ANALYSIS_TIMESPAN_COLUMN_WIDTH.getWidth() );
         timestampColumn.getColumn().setWidth( (int)(widthProvider.getTimestampColumnWidth()) );
+        tagColumn.getColumn().setWidth( TableColumnWidthProvider.FixedColumnWidths.TAG_COLUMN_WIDTH.getWidth() );
+        colorColumn.getColumn().setWidth( TableColumnWidthProvider.FixedColumnWidths.COLOR_COLUMN_WIDTH.getWidth() );
         valueColumns.stream().forEach( current -> {
             TableColumn currentColumn = current.getColumn();
             long width = currentColumn.getText().toLowerCase().equals( "value" )
@@ -353,9 +363,7 @@ public class RuntimeEventLoggerTableEditor extends EditorPart
     {
         CellLabelProvider labelProvider = new AnalysisTimespanColumnLabelProvider( analysisTimespanPreferences,
                                                                                    userInteractionPreferences );
-        TableViewerColumn analysisColumn = filteredTable.createColumn( "", labelProvider );
-        analysisColumn.getColumn()
-                .setWidth( TableColumnWidthProvider.FixedColumnWidths.ANALYSIS_TIMESPAN_COLUMN_WIDTH.getWidth() );
+        analysisColumn = filteredTable.createColumn( "", labelProvider );
         analysisColumn.getColumn().setResizable( false );
     }
 
@@ -375,8 +383,7 @@ public class RuntimeEventLoggerTableEditor extends EditorPart
                                                                                new ImageCreator( this.getTreeViewer()
                                                                                        .getControl() ),
                                                                                backgroundColorCreator );
-        TableViewerColumn tagColumn = filteredTable.createColumn( "", tagColumnLabelProvider );
-        tagColumn.getColumn().setWidth( TableColumnWidthProvider.FixedColumnWidths.TAG_COLUMN_WIDTH.getWidth() );
+        tagColumn = filteredTable.createColumn( "", tagColumnLabelProvider );
         tagColumn.getColumn().setResizable( false );
 
         ColumnViewerToolTipSupport.enableFor( tagColumn.getViewer() );
@@ -435,8 +442,7 @@ public class RuntimeEventLoggerTableEditor extends EditorPart
     private void createColorColumn()
     {
         labelProvider = new ColorColumnLabelProvider();
-        TableViewerColumn colorColumn = filteredTable.createColumn( "", labelProvider );
-        colorColumn.getColumn().setWidth( TableColumnWidthProvider.FixedColumnWidths.COLOR_COLUMN_WIDTH.getWidth() );
+        colorColumn = filteredTable.createColumn( "", labelProvider );
         colorColumn.getColumn().setResizable( false );
     }
 

--- a/src/com.elektrobit.ebrace.viewer.runtimeeventloggertable/src/com/elektrobit/ebrace/viewer/runtimeeventloggertable/editor/RuntimeEventLoggerTableEditor.java
+++ b/src/com.elektrobit.ebrace.viewer.runtimeeventloggertable/src/com/elektrobit/ebrace/viewer/runtimeeventloggertable/editor/RuntimeEventLoggerTableEditor.java
@@ -402,11 +402,12 @@ public class RuntimeEventLoggerTableEditor extends EditorPart
 
         List<String> channelsWithoutDuplicates = allColumnNames.stream().distinct().collect( Collectors.toList() );
 
+        // "Value" column should be rightmost before the channel column
+        addAdditionalValueColumn( "Value" );
+
         channelsWithoutDuplicates.stream().filter( columnName -> !columnName.equals( "Value" ) )
                 .forEach( columnName -> addAdditionalValueColumn( columnName ) );
 
-        // "Value" column should be rightmost before the channel column
-        addAdditionalValueColumn( "Value" );
     }
 
     private void addAdditionalValueColumn(String columnName)


### PR DESCRIPTION
In case a log4j trace
	* is logged with starting "ipc" as log identifier
	* and the payload is valid json
	* and the payload contains "edge" as JsonObject on topLevel

Then this trace is considered to be a IPC call and the trace content is
transformed into the generich EB solys message format.

All other traces are logged as plain text.