### PR TITLE
Fix for re-rendering HTML Content in Browser

### DIFF
--- a/src/com.elektrobit.ebrace.core.scriptimporter/files/RaceScripts/src/api/ScriptBase.xtend
+++ b/src/com.elektrobit.ebrace.core.scriptimporter/files/RaceScripts/src/api/ScriptBase.xtend
@@ -257,7 +257,21 @@ class ScriptBase {
 		val htmlView = createOrGetHtmlView(htmlViewName)
 		htmlView.content = 
 		'''
-			<html><object data="«pathToPNG»" type="image/png"/></html>
+		<html>
+		<head>
+			<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+			<script type="text/javascript">
+				function reloadImg() {
+					d = new Date();
+					$("#imageId").attr("src", "«pathToPNG»?"+d.getTime());		
+				}
+			</script>
+		</head>
+		<body>
+			<img id="imageId" />
+			<script type="text/javascript">reloadImg()</script>
+		</body>
+		</html>
 		'''
 	}
 	


### PR DESCRIPTION
Problem:
SVG Rendering in JavaFX Web Engine does not look tidy in some case.
Therefore rendering output was changed from SVG into PNG

But changed PNG content is not recognized by the Browser, and thus no
reason to re-render the HTML.

The generated HTML code now calls an embedded javascript function, which
forces the browser to reload the image.