### PR TITLE
Scanning source code with jqassistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ hs_err_pid*
 src/buildroot/**/*
 /**/src-gen/**/*
 /**/src-org/**/*
+
+# JQassist
+jqassist/store

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ src/buildroot/**/*
 /**/src-org/**/*
 
 # JQassist
-jqassist/store
+/jqassistant/store/

--- a/src/com.elektrobit.ebrace.releng.parent/pom.xml
+++ b/src/com.elektrobit.ebrace.releng.parent/pom.xml
@@ -11,10 +11,33 @@
 	<name>EB solys Parent POM</name>
 	<properties>
 		<tycho-version>0.26.0</tycho-version>
+		<jqassistant.version>1.3.0</jqassistant.version>		
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
-		<plugins>
+		<plugins>		
+			<plugin>
+			  <groupId>com.buschmais.jqassistant</groupId>
+			  <artifactId>jqassistant-maven-plugin</artifactId>
+			  <version>${jqassistant.version}</version>
+			  <executions>
+				<execution>
+				  <id>default</id>
+				  <goals>
+					<goal>scan</goal>
+					<goal>analyze</goal>
+				  </goals>
+				  <configuration>
+					<warnOnSeverity>INFO</warnOnSeverity>
+					<failOnSeverity>MAJOR</failOnSeverity>
+					<store>
+						<uri>file:../../jqassistant/store</uri>
+					</store>
+					<useExecutionRootAsProjectRoot>true</useExecutionRootAsProjectRoot>					
+				  </configuration>
+				</execution>
+			  </executions>
+			</plugin>				
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>target-platform-configuration</artifactId>


### PR DESCRIPTION
This will add a dependency to jqassistant, in order to scan all project artifacts and store them into a neo4j database

The resulting db will be generated to the <solys_root_dir>/jqassistant/store

The db will not be under version control and hence added to the .gitignore